### PR TITLE
Enable Intranode Visibility

### DIFF
--- a/modules/gcp-environment/compute.tf
+++ b/modules/gcp-environment/compute.tf
@@ -5,15 +5,16 @@ resource "google_service_account" "main_cluster_sa" {
 }
 
 resource "google_container_cluster" "main_cluster" {
-  project                  = var.gcp_project_id
-  name                     = local.main_cluster_name
-  location                 = var.gcp_region
-  network                  = google_compute_network.main.self_link
-  subnetwork               = google_compute_subnetwork.main_cluster.self_link
-  enable_shielded_nodes    = var.main_cluster_features.enable_shielded_nodes
-  initial_node_count       = 1
-  remove_default_node_pool = true
-  deletion_protection      = local.deletion_protection_enabled
+  project                     = var.gcp_project_id
+  name                        = local.main_cluster_name
+  location                    = var.gcp_region
+  network                     = google_compute_network.main.self_link
+  subnetwork                  = google_compute_subnetwork.main_cluster.self_link
+  enable_shielded_nodes       = var.main_cluster_features.enable_shielded_nodes
+  initial_node_count          = 1
+  enable_intranode_visibility = true
+  remove_default_node_pool    = true
+  deletion_protection         = local.deletion_protection_enabled
 
   # Accept known production-ready upgrades for GKE by default
   # https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels

--- a/modules/gcp-environment/network.tf
+++ b/modules/gcp-environment/network.tf
@@ -70,7 +70,7 @@ resource "google_compute_router_nat" "main" {
 # communication with the control plane on other ports, we need to explicitly allow it.
 # Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 resource "google_compute_firewall" "gke_control_plane_tcp_port_node_access" {
-  count = length(var.main_cluster_authorized_control_plane_ports) > 0 ? 1 : 0
+  count         = length(var.main_cluster_authorized_control_plane_ports) > 0 ? 1 : 0
   project       = var.gcp_project_id
   name          = "main-cluster-control-plane-tcp-node-access"
   description   = <<-EOT

--- a/modules/gcp-environment/network.tf
+++ b/modules/gcp-environment/network.tf
@@ -39,7 +39,7 @@ resource "google_compute_router" "main" {
 }
 
 resource "google_compute_address" "nat_gateway_manual_ip" {
-  count   = var.enable_manual_nat_ip ? local.nat_router_compute_address_count : 0
+  count   = var.enable_static_nat_ip ? local.nat_router_compute_address_count : 0
   name    = "nat-manual-ip-${count.index}"
   project = var.gcp_project_id
   region  = google_compute_subnetwork.main_cluster.region
@@ -50,8 +50,8 @@ resource "google_compute_router_nat" "main" {
   project                            = var.gcp_project_id
   region                             = var.gcp_region
   router                             = google_compute_router.main.name
-  nat_ip_allocate_option             = var.enable_manual_nat_ip ? "MANUAL_ONLY" : "AUTO_ONLY"
-  nat_ips                            = var.enable_manual_nat_ip ? google_compute_address.nat_gateway_manual_ip.*.self_link : null
+  nat_ip_allocate_option             = var.enable_static_nat_ip ? "MANUAL_ONLY" : "AUTO_ONLY"
+  nat_ips                            = var.enable_static_nat_ip ? google_compute_address.nat_gateway_manual_ip.*.self_link : null
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
     name                    = google_compute_subnetwork.main_cluster.self_link

--- a/modules/gcp-environment/variables.tf
+++ b/modules/gcp-environment/variables.tf
@@ -28,11 +28,12 @@ variable "env_region" {
   }
 }
 
-variable "enable_manual_nat_ip" {
+variable "enable_static_nat_ip" {
   description = <<-EOT
-    Enables manual NAT IP allocation when provisioning the environment's NAT gateway.
+    Enables manual NAT IP allocation when provisioning the environment's NAT gateway which automatically assigns several static IP addresses to the NAT router.
     This is used as a way to provide a stable IP address to applications within the cluster when calling out to external services.
   EOT
+  type        = bool
   default     = false
 }
 

--- a/modules/gcp-environment/variables.tf
+++ b/modules/gcp-environment/variables.tf
@@ -68,7 +68,7 @@ variable "gcp_service_accounts" {
     create_key              = optional(bool, false)
     workload_identity_users = optional(list(string), [])
   }))
-  default     = {}
+  default = {}
 }
 
 variable "k8s_workload_service_accounts" {
@@ -78,13 +78,13 @@ variable "k8s_workload_service_accounts" {
   EOT
   type = map(
     object({
-      roles         = set(string)
-      namespaces    = set(string)
-      create_key    = optional(bool, false)
-      k8s_sa_name   = optional(string) # This will be set to the K8s SA name when it doesn't match the GCP SA name
+      roles       = set(string)
+      namespaces  = set(string)
+      create_key  = optional(bool, false)
+      k8s_sa_name = optional(string) # This will be set to the K8s SA name when it doesn't match the GCP SA name
     })
   )
-  default     = {}
+  default = {}
 }
 
 ##############################
@@ -147,8 +147,8 @@ variable "main_cluster_authorized_control_plane_ports" {
     service mesh or ingress controller. See https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
     for more info.
   EOT
-  type = list(number)
-  default = []
+  type        = list(number)
+  default     = []
 }
 
 variable "main_cluster_default_node_availability_zones" {


### PR DESCRIPTION
This PR enables the GKE feature known as [Intranode Visibility](https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility) so that pod to pod traffic is made visible to the VPC of the GCP environment. This option allows for firewall rules to be applied to pod-to-pod traffic and for flow logs to be captured for pod traffic.

Additionally, while I was here I ran `terraform fmt -recursive` and addressed some variable naming inconsistencies.